### PR TITLE
Clarify Reset method behavior in Buzzer class

### DIFF
--- a/AteChips/Core/Buzzer/Buzzer.cs
+++ b/AteChips/Core/Buzzer/Buzzer.cs
@@ -27,6 +27,9 @@ public partial class Buzzer : IBuzzer
 
     public void Reset()
     {
+        // No need to flush anything; just let the host produce silence when needed.
+        // All the settings are host related, so they shouldn't be reset when the device
+        // is reset.
     }
 
     public bool IsMuted { get; set; } = false;


### PR DESCRIPTION
Added comments to the `Reset` method to explain that there is no need to flush anything and that host-related settings should not be reset when the device is reset.

Closes #2 