### PR TITLE
Add LOUDNESS_CURVE constant and adjust volume behavior

### DIFF
--- a/AteChips/Core.Visuals/Buzzer.Visualizer.cs
+++ b/AteChips/Core.Visuals/Buzzer.Visualizer.cs
@@ -16,7 +16,7 @@ public partial class Buzzer
     private int? _selectedDeviceIndex;
     private List<(int Index, string Name)>? _deviceList;
     private bool _deviceListInitialized;
-
+    private const float LOUDNESS_CURVE = 2.2f;
     const float TIME_WINDOW_SECONDS = 0.016f;
     private int _sampleCount;
     private float[] _waveform = null!;
@@ -97,7 +97,9 @@ public partial class Buzzer
 
         ImGuiWidgets.Checkbox("Mute", () => IsMuted, v => IsMuted = v);
         ImGuiWidgets.SliderFloat("Pitch (Hz)", () => Pitch, v => Pitch = v, 50f, 2000f);
-        ImGuiWidgets.SliderFloat("Volume", () => Volume, v => Volume = v);
+        ImGuiWidgets.SliderFloat("Volume", 
+            () => MathF.Pow(Volume, 1f / LOUDNESS_CURVE), 
+            value => Volume = MathF.Pow(value, LOUDNESS_CURVE));
 
         string[] waveforms = Enum.GetNames<WaveformType>();
         string selectedName = Waveform.ToString();

--- a/AteChips/Core/Buzzer/Buzzer.cs
+++ b/AteChips/Core/Buzzer/Buzzer.cs
@@ -34,7 +34,7 @@ public partial class Buzzer : IBuzzer
 
     public bool IsMuted { get; set; } = false;
     public float Pitch { get; set; } = 440.0f;
-    public float Volume { get; set; } = 0.6f;
+    public float Volume { get; set; } = 0.4f;
     public bool TestTone { get; set; } = false;
     public float PulseDutyCycle { get; set; } = 0.25f;
     public float RoundedSharpness { get; set; } = 15.0f;


### PR DESCRIPTION
Introduced a new constant `LOUDNESS_CURVE` in `Buzzer.Visualizer.cs` to modify volume scaling in the visualizer. Updated the volume slider to use a non-linear adjustment with `MathF.Pow`.

Changed the default `Volume` value in `Buzzer.cs` from `0.6f` to `0.4f` for a lower initial volume setting.

Closes #12 