### PR TITLE
Refactor waveform normalization in Buzzer class

### DIFF
--- a/AteChips/Core.Visuals/Buzzer.Visualizer.cs
+++ b/AteChips/Core.Visuals/Buzzer.Visualizer.cs
@@ -202,17 +202,25 @@ public partial class Buzzer
         float phase = 0.0f;
         float phaseIncrement = TAU * Pitch / SampleRate;
 
+        float sumSquares = 0f;
+
         for (int i = 0; i < _sampleCount; i++)
         {
             float t = i / (float)SampleRate;
+            float sample = GetWaveformSample((phase / TAU) % 1f, t); // Phase normalized to [0,1)
 
-            _waveform[i] = GetWaveformSample(phase / TAU % 1f, t) * Volume;
+            _waveform[i] = sample * Volume;
+
+            sumSquares += sample * sample;
+
             phase += phaseIncrement;
             if (phase >= TAU)
-            {
                 phase -= TAU;
-            }
         }
+
+        // Calculate and store normalization factor
+        float rms = MathF.Sqrt(sumSquares / _sampleCount);
+        _normalizationFactor = (rms == 0f) ? 1f : 1f / rms;
 
         _lastVisualizedSettings = CurrentSettings;
     }

--- a/AteChips/Core/Buzzer/Buzzer.cs
+++ b/AteChips/Core/Buzzer/Buzzer.cs
@@ -16,6 +16,7 @@ public partial class Buzzer : IBuzzer
     public int Channels => 2;
     private readonly CrystalTimer _timer;
     private float _currentAmplitude;
+    private float? _normalizationFactor;
 
     public Buzzer(CrystalTimer timer)
     {
@@ -48,6 +49,9 @@ public partial class Buzzer : IBuzzer
 
     public int GetSamples(float[] buffer, int offset, int count)
     {
+
+        if (_normalizationFactor is null) { GenerateWaveformPreview(); }
+
         bool makingSound = (_timer.SoundTimer > 0 && !IsMuted) || TestTone;
 
         float frequency = Pitch;
@@ -61,7 +65,7 @@ public partial class Buzzer : IBuzzer
             // Smoothly approach target amplitude
             _currentAmplitude += (targetAmplitude - _currentAmplitude) * fadeSpeed;
 
-            float sample = GetWaveformSample(_phase, _totalSamplesGenerated) * _currentAmplitude * GetNormalizationFactor(Waveform);
+            float sample = GetWaveformSample(_phase, _totalSamplesGenerated) * _currentAmplitude * _normalizationFactor!.Value;
 
             buffer[offset + i] = sample;       // Left
             buffer[offset + i + 1] = sample;   // Right
@@ -76,10 +80,6 @@ public partial class Buzzer : IBuzzer
         _totalSamplesGenerated += count / Channels;
         return count;
     }
-
-
-
-    public static float GetNormalizationFactor(WaveformType type) => 0.1f;
 
     protected float GetWaveformSample(float phase, float time)
     {


### PR DESCRIPTION
- Updated `GenerateWaveformPreview` to calculate RMS and normalization factor.
- Introduced nullable `_normalizationFactor` in `Buzzer.cs`.
- Modified `GetSamples` to use `_normalizationFactor` instead of a static method.
- Removed the static `GetNormalizationFactor` method.
- Enhanced waveform generation accuracy by relying on instance variable for normalization.

Closes #13 