### PR TITLE
Add Curvature visual effect and settings to display

### DIFF
--- a/AteChips/Host/Video/Display.Visualizer.cs
+++ b/AteChips/Host/Video/Display.Visualizer.cs
@@ -35,6 +35,7 @@ public partial class Display
         PhosphorDecay();
         CrtScanLines();
         Bloom();
+        Curvature();
         
         //ImGui.Checkbox("Curvature", ref _postProcessor.EnableCurvature);
         //if (_postProcessor.EnableCurvature &&
@@ -247,6 +248,52 @@ public partial class Display
 
     }
 
+    void Curvature()
+    {
+        ImGuiWidgets.Checkbox("CRT Curvature",
+            () => _videoSettings.CurvatureSettings.IsEnabled,
+            value =>
+            {
+                _videoSettings.CurvatureSettings.IsEnabled = value;
+                SettingsChanged?.Invoke();
+            });
+
+        if (_videoSettings.CurvatureSettings.IsEnabled)
+        {
+
+            ImGuiWidgets.SliderFloat("Horizontal Curve (X)",
+                () => _videoSettings.CurvatureSettings.CurvatureX,
+                value =>
+                {
+                    _videoSettings.CurvatureSettings.CurvatureX = value;
+                    SettingsChanged?.Invoke();
+                }, 0.0f, 0.5f);
+
+            ImGuiWidgets.SliderFloat("Vertical Curve (Y)",
+                () => _videoSettings.CurvatureSettings.CurvatureY,
+                value =>
+                {
+                    _videoSettings.CurvatureSettings.CurvatureY = value;
+                    SettingsChanged?.Invoke();
+                }, 0.0f, 0.5f);
+            ImGuiWidgets.SliderFloat("Horizontal Warp (X)",
+                () => _videoSettings.CurvatureSettings.WarpX,
+                value =>
+                {
+                    _videoSettings.CurvatureSettings.WarpX = value;
+                    SettingsChanged?.Invoke();
+                }, -0.2f, 0.2f);
+
+            ImGuiWidgets.SliderFloat("Vertical Warp (Y)",
+                () => _videoSettings.CurvatureSettings.WarpY,
+                value =>
+                {
+                    _videoSettings.CurvatureSettings.WarpY = value;
+                    SettingsChanged?.Invoke();
+                }, -0.2f, 0.2f);
+        }
+
+    }
 
 
 }

--- a/AteChips/Host/Video/Display.cs
+++ b/AteChips/Host/Video/Display.cs
@@ -158,6 +158,7 @@ partial class Display : IVisualizable, IDrawable, ISettingsChangedNotifier
         ShaderPipeline.AddEffect(new PhosphorDecay(_vao, _videoSettings.PhosphorDecaySettings));
         ShaderPipeline.AddEffect(new Scanlines(_vao, _videoSettings.ScanlineSettings));
         ShaderPipeline.AddEffect(new Bloom(_vao, _videoSettings.BloomSettings));
+        ShaderPipeline.AddEffect(new Curvature(_vao, _videoSettings.CurvatureSettings));
     }
 
     /// <summary>

--- a/AteChips/Host/Video/EffectSettings/CurvatureSettings.cs
+++ b/AteChips/Host/Video/EffectSettings/CurvatureSettings.cs
@@ -1,0 +1,18 @@
+﻿namespace AteChips.Host.Video.EffectSettings;
+
+public class CurvatureSettings
+{
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Horizontal curvature strength. Recommended range: 0.0 to 0.3
+    /// </summary>
+    public float CurvatureX { get; set; } = 0.1f;
+
+    /// <summary>
+    /// Vertical curvature strength. Recommended range: 0.0 to 0.3
+    /// </summary>
+    public float CurvatureY { get; set; } = 0.15f;
+    public float WarpX { get; set; } = 0.0f;
+    public float WarpY { get; set; } = 0.0f;
+}

--- a/AteChips/Host/Video/Shaders/CrtCurvature.frag.glsl
+++ b/AteChips/Host/Video/Shaders/CrtCurvature.frag.glsl
@@ -1,0 +1,42 @@
+#version 330 core
+
+in vec2 TexCoord;
+out vec4 FragColor;
+
+uniform sampler2D Texture;
+
+// Per-axis curvature (applies non-radial distortion)
+uniform float CurvatureX;
+uniform float CurvatureY;
+
+// Per-axis warp (true barrel/pincushion: radial, but asymmetric)
+uniform float WarpX;
+uniform float WarpY;
+
+void main()
+{
+    // Flip Y to match top-left origin
+    vec2 flippedTexCoord = vec2(TexCoord.x, 1.0 - TexCoord.y);
+
+    // Normalize coordinates to [-1, 1], centered at screen
+    vec2 centered = flippedTexCoord * 2.0 - 1.0;
+
+    // --- Apply directional warp (barrel/pincushion) ---
+    float r2 = dot(centered, centered);
+    vec2 warped;
+    warped.x = centered.x * (1.0 + WarpX * r2);
+    warped.y = centered.y * (1.0 + WarpY * r2);
+
+    // --- Apply additional per-axis curvature (squash/stretch) ---
+    warped.x = warped.x * (1.0 + CurvatureX * (centered.y * centered.y));
+    warped.y = warped.y * (1.0 + CurvatureY * (centered.x * centered.x));
+
+    // Convert back to [0, 1] texture coordinates
+    vec2 finalUV = warped * 0.5 + 0.5;
+
+    // Optional: Clamp or discard outside bounds
+    if (finalUV.x < 0.0 || finalUV.x > 1.0 || finalUV.y < 0.0 || finalUV.y > 1.0)
+        discard;
+
+    FragColor = texture(Texture, finalUV);
+}

--- a/AteChips/Host/Video/Shaders/Curvature.cs
+++ b/AteChips/Host/Video/Shaders/Curvature.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using AteChips.Host.Video.EffectSettings;
+using OpenTK.Graphics.OpenGL4;
+
+namespace AteChips.Host.Video.Shaders;
+
+public class Curvature : IShaderEffect
+{
+
+    private readonly int _vao;
+    private readonly CurvatureSettings _settings;
+    private readonly int _shader;
+    private int _curveXLocation;
+    private int _curveYLocation;
+    private int _warpXLocation;
+    private int _warpYLocation;
+    private int _fboOutput;
+    private int _texOutput;
+
+    public Curvature(int fullscreenQuadVao, CurvatureSettings settings)
+    {
+        _vao = fullscreenQuadVao;
+        _settings = settings;
+        _shader = CreateShaderProgram();
+    }
+
+    private int CreateShaderProgram()
+    {
+        int vertex = IShaderEffect.CreateShader("Basic.vert.glsl", ShaderType.VertexShader);
+        int fragment = IShaderEffect.CreateShader("CrtCurvature.frag.glsl", ShaderType.FragmentShader);
+
+        int program = GL.CreateProgram();
+        GL.AttachShader(program, vertex);
+        GL.AttachShader(program, fragment);
+        GL.LinkProgram(program);
+
+        GL.DeleteShader(vertex);
+        GL.DeleteShader(fragment);
+
+        _curveXLocation = GL.GetUniformLocation(program, "CurvatureX");
+        _curveYLocation = GL.GetUniformLocation(program, "CurvatureY");
+        _warpXLocation = GL.GetUniformLocation(program, "WarpX");
+        _warpYLocation = GL.GetUniformLocation(program, "WarpY");
+
+        return program;
+    }
+
+    public int Apply(int newFrameTexture, int width, int height)
+    {
+        if (!_settings.IsEnabled)
+            return newFrameTexture;
+
+        // Ensure output FBO/texture is sized correctly
+        CreateOrResize(ref _fboOutput, ref _texOutput, width, height);
+
+        // Bind output framebuffer
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, _fboOutput);
+        GL.Viewport(0, 0, width, height);
+        GL.Clear(ClearBufferMask.ColorBufferBit);
+
+        // Use curvature shader
+        GL.UseProgram(_shader);
+
+        // Bind input texture
+        GL.ActiveTexture(TextureUnit.Texture0);
+        GL.BindTexture(TextureTarget.Texture2D, newFrameTexture);
+
+        // Set uniforms
+        GL.Uniform1(_curveXLocation, _settings.CurvatureX);
+        GL.Uniform1(_curveYLocation, _settings.CurvatureY);
+        GL.Uniform1(_warpXLocation, _settings.WarpX);
+        GL.Uniform1(_warpYLocation, _settings.WarpY);
+
+        // Draw quad
+        GL.BindVertexArray(_vao);
+        GL.DrawArrays(PrimitiveType.Triangles, 0, 6);
+
+        return _texOutput;
+    }
+
+    private void CreateOrResize(ref int fbo, ref int tex, int width, int height)
+    {
+        if (tex != 0)
+        {
+            GL.DeleteFramebuffer(fbo);
+            GL.DeleteTexture(tex);
+        }
+
+        tex = GL.GenTexture();
+        GL.BindTexture(TextureTarget.Texture2D, tex);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, width, height, 0,
+            PixelFormat.Rgba, PixelType.UnsignedByte, IntPtr.Zero);
+        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
+        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+
+        fbo = GL.GenFramebuffer();
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fbo);
+        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0,
+            TextureTarget.Texture2D, tex, 0);
+    }
+
+}

--- a/AteChips/Host/Video/VideoSettings.cs
+++ b/AteChips/Host/Video/VideoSettings.cs
@@ -31,6 +31,8 @@ public record VideoSettings
 
     public BloomSettings BloomSettings { get; set; } = new();
 
+    public CurvatureSettings CurvatureSettings { get; set; } = new();
+
     [JsonIgnore]
     public PhosphorColor RenderPhosphorColor =>
         PhosphorColorType switch


### PR DESCRIPTION
✅ **Curvature and Warp Shader Completed**

The CRT curvature effect is now fully implemented and integrated:

- 🌀 **Per-axis curvature** (`CurvatureX`, `CurvatureY`)
- 🎯 **True barrel/pincushion warp** (`WarpX`, `WarpY`) using radial distortion
- 🔄 **Y-flip correction** to align texture origin with screen-space
- 🧪 ImGui UI with live sliders for all parameters
- 🧵 Modular shader class implementing `IShaderEffect`
- 🖼️ Final shader correctly applied **after** all other effects (e.g., scanlines, vignette)

Shader path:  
`Shaders/CrtCurvature.frag`

Settings:  
`VideoSettings.CurvatureSettings`

ImGui panel:  
Located in the main video effect settings drawer.

This closes #32. 🎉
